### PR TITLE
Add link to QBE in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 ## About 
-Glove is a library for working with QBE intermediate representation (IR) in Gleam. Provides utilities and functions to generate QBE code using the Gleam programming language. 
+Glove is a library for working with [QBE](https://c9x.me/compile/) intermediate representation (IR) in Gleam. Provides utilities and functions to generate QBE code using the Gleam programming language.
 
 ## Requirements
 


### PR DESCRIPTION
This PR adds a link to the QBE site the first time it's mentioned, as for folks unfamiliar with QBE (like myself), it can be hard to find easily.

I was wondering what IR had to do with an insurance company 😄 

<img width="654" alt="Screenshot 2023-05-31 at 9 45 02 AM" src="https://github.com/Willyboar/glove/assets/1486634/f1839769-0b70-4003-81a7-9f190fdf6c82">
